### PR TITLE
fix: added note of tpg is written in C++ within MIS intro

### DIFF
--- a/docs/Design/SoftDetailedDes/MIS.tex
+++ b/docs/Design/SoftDetailedDes/MIS.tex
@@ -101,6 +101,7 @@ See SRS Documentation at \href{https://github.com/TPGEngine/tpg/blob/main/docs/S
 
 The following document details the Module Interface Specifications for
 \progname{}. The Tangled Program Graphs (TPG) framework is developing an interface to test the evolutionary machine learning framework Tangle Programming Graphs (TPG) in a robotic simulation engine called MuJoCo created by Google Deepmind.
+The TPG project is written in C++, and C++ notation will be utilized within this document as such.
 
 
 


### PR DESCRIPTION
## 🔗 Related Issue(s)

<!--- List the links to the related issue(s) -->
-

## 📝 Description

<!-- Please include a summary of the changes and the related issue(s) -->
added note of tpg is written in C++ within MIS intro

## ✅ How Has This Been Tested?

<!--- Outline the steps you took to test your changes. Include any test cases or scenarios you used. -->
