### PR TITLE
fix register machine unused variables warning

### DIFF
--- a/src/tests/register_machine_crossover_test.cc
+++ b/src/tests/register_machine_crossover_test.cc
@@ -80,6 +80,8 @@ TEST_CASE("RegisterMachine Crossover Test", "[TPG]") {
          }
       }
 
+      CHECK(has_different_instructions);
+
       // Cleanup
       delete parent1;
       delete parent2;
@@ -177,7 +179,8 @@ TEST_CASE("RegisterMachine Crossover Test", "[TPG]") {
          // Ensure crossover points are within the allowed distance, // Example: dcmax = 25
 
          // distance | i1 − i2 |≤ min(l(gp1) − 1, dcmax) 
-
+         INFO(p1Size);
+         INFO(p2Size);
 
          INFO(c1Size);
          INFO(c2Size);


### PR DESCRIPTION
## 🔗 Related Issue(s)

<!--- List the links to the related issue(s) -->
- N/A

## 📝 Description

<!-- Please include a summary of the changes and the related issue(s) -->
When running cmake, a warning shows:
```
/home/runner/work/tpg/tpg/src/tests/register_machine_crossover_test.cc: In function ‘void CATCH2_INTERNAL_TEST_0()’:
/home/runner/work/tpg/tpg/src/tests/register_machine_crossover_test.cc:73:12: warning: variable ‘has_different_instructions’ set but not used [-Wunused-but-set-variable]
   73 |       bool has_different_instructions = false;
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/tpg/tpg/src/tests/register_machine_crossover_test.cc:160:11: warning: unused variable ‘p1Size’ [-Wunused-variable]
  160 |       int p1Size = static_cast<int>(p1->instructions_.size());
      |           ^~~~~~
/home/runner/work/tpg/tpg/src/tests/register_machine_crossover_test.cc:161:11: warning: unused variable ‘p2Size’ [-Wunused-variable]
  161 |       int p2Size = static_cast<int>(p2->instructions_.size());
      |           ^~~~~~
```

## ✅ How Has This Been Tested?

<!--- Outline the steps you took to test your changes. Include any test cases or scenarios you used. -->
Deleted `/build` and reran cmake. Warning is gone.
