### PR TITLE
Removed FR-SLN6 as that was not a test ID that was created before.

### DIFF
--- a/docs/VnVReport/VnVReport.tex
+++ b/docs/VnVReport/VnVReport.tex
@@ -40,6 +40,7 @@
 \toprule {\bf Date} & {\bf Version} & {\bf Notes}\\
 \midrule
 3/10/2025 & 1.0 & First write up of VnV Report \\
+3/18/2025 & 1.1 & Fixed extra FR-SLN6 test case \\
 \bottomrule
 \end{tabularx}
 
@@ -134,14 +135,9 @@ This document cohesively summarizes the results of each test as specified in the
   \textbf{Test Id} & \textbf{Notes} & \textbf{Result} \\
   \hline
   \endhead
-      FR-SLN4 & Affirmed that the “Build TPG Project” pipeline properly builds the TPG framework with updated code when changes are pushed to any branch. & Pass \\
+    FR-SLN4 & Affirmed that the “Build TPG Project” pipeline properly builds the TPG framework with updated code when changes are pushed to any branch, the TPG unit test cases are also automatically ran, and the build will only pass if all the unit tests passes. & Pass \\
   \hline
-  FR-SLN5 & When the project building pipeline runs properly, the TPG unit test cases are also automatically ran, and the build will only pass if all the unit tests passes
-  . & Pass \\
-  \hline
-
-  FR-SLN6 & Tested that linting and Latex compilation pipeline works as expected. & Pass \\
-
+    FR-SLN5 & Tested that linting and Latex compilation pipeline works as expected. & Pass \\
   \hline
   \end{longtable}
 \end{center}


### PR DESCRIPTION
## 🔗 Related Issue(s)

<!--- List the links to the related issue(s) -->
- #399

## 📝 Description

<!-- Please include a summary of the changes and the related issue(s) -->
Looking back, the GitHub Actions Ci/CD section references FR-SLN6. This test id had not been identified in any other documents and was confused for FR-SLN4 and FR-SLN5. This has been removed and as a result ,the traceability matrix is now consistent.

## ✅ How Has This Been Tested?

<!--- Outline the steps you took to test your changes. Include any test cases or scenarios you used. -->
- Ensured PDF compiled locally. 
